### PR TITLE
feat: add modern web UI with spectrogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,19 @@ Visit:
 cpp
 Copy code
 http://<your-pi-ip>:5010
+Run the modern dashboard:
+
+```bash
+python scripts/ui_server.py
+```
+
 Features:
 
-Timeline of speech events
-
-Full transcripts
-
-Classification tags
-
-Search/filter by keyword, date, or category
+- Modern Bootstrap UI with most recent recording and spectrogram
+- Timeline of speech events
+- Full transcripts
+- Classification tags
+- Search/filter by keyword, date, or category
 
 Use Cases
 Language and dialect detection

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>HUMINT-Pi Dashboard</title>
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+  />
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1 class="mb-4">HUMINT-Pi Dashboard</h1>
+    <div id="recent" class="mb-4">
+      <h2>Most Recent Capture</h2>
+      <p id="info">Loading…</p>
+      <canvas id="spec" class="img-fluid mb-2"></canvas>
+      <audio id="player" controls class="w-100"></audio>
+    </div>
+    <button id="refresh" class="btn btn-primary">Refresh</button>
+  </div>
+
+  <script>
+    async function loadRecent() {
+      const infoEl = document.getElementById('info');
+      infoEl.textContent = 'Loading…';
+      try {
+        const res = await fetch('/api/recent');
+        if (!res.ok) {
+          infoEl.textContent = 'No recordings found';
+          return;
+        }
+        const data = await res.json();
+        infoEl.textContent = `${data.filename} (recorded ${new Date(data.timestamp).toLocaleString()})`;
+
+        const audio = document.getElementById('player');
+        audio.src = `/api/audio/${encodeURIComponent(data.filename)}`;
+
+        const specRes = await fetch(`/api/spectrogram/${encodeURIComponent(data.filename)}`);
+        const blob = await specRes.blob();
+        const url = URL.createObjectURL(blob);
+        const img = new Image();
+        img.onload = () => {
+          const canvas = document.getElementById('spec');
+          canvas.width = img.width;
+          canvas.height = img.height;
+          canvas.getContext('2d').drawImage(img, 0, 0);
+          URL.revokeObjectURL(url);
+        };
+        img.src = url;
+      } catch (err) {
+        infoEl.textContent = 'Error loading recording';
+        console.error(err);
+      }
+    }
+
+    document.getElementById('refresh').addEventListener('click', loadRecent);
+    loadRecent();
+  </script>
+</body>
+</html>
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ pytest==7.1.2
 pytest-mock==3.7.0
 suntime
 altair<5
+Flask==2.3.2
+matplotlib

--- a/scripts/ui_server.py
+++ b/scripts/ui_server.py
@@ -1,0 +1,107 @@
+"""Simple Flask server providing a modern web UI for HUMINT-Pi.
+
+This server exposes a dashboard showing the most recent audio capture
+and a dynamically generated spectrogram.  It is intentionally lightweight
+and does not require the full BirdNET-Pi PHP stack.
+
+Run with:
+    python scripts/ui_server.py
+
+The server expects recorded audio files to be stored in ``recordings/``
+at the project root.  Spectrograms are generated on demand using
+``librosa`` and ``matplotlib``.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime
+from pathlib import Path
+
+import librosa
+import librosa.display  # noqa: F401  - needed for specshow
+import numpy as np
+from flask import Flask, abort, jsonify, send_file, send_from_directory
+import matplotlib.pyplot as plt
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+RECORDINGS_DIR = BASE_DIR / "recordings"
+
+
+app = Flask(
+    __name__,
+    static_folder=str(BASE_DIR / "homepage"),
+    template_folder=str(BASE_DIR / "homepage"),
+)
+
+
+@app.route("/")
+def index() -> object:
+    """Return the dashboard page."""
+    return send_from_directory(app.static_folder, "index.html")
+
+
+@app.route("/api/recent")
+def recent_capture() -> object:
+    """Return metadata for the most recent recording.
+
+    Returns an empty 404 JSON response if no recordings are present.
+    """
+
+    if not RECORDINGS_DIR.exists():
+        return jsonify({}), 404
+
+    wavs = sorted(
+        RECORDINGS_DIR.glob("*.wav"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not wavs:
+        return jsonify({}), 404
+
+    latest = wavs[0]
+    return jsonify(
+        {
+            "filename": latest.name,
+            "timestamp": datetime.fromtimestamp(latest.stat().st_mtime).isoformat(),
+        }
+    )
+
+
+@app.route("/api/audio/<path:filename>")
+def serve_audio(filename: str):
+    """Serve a raw audio file for playback."""
+    file_path = RECORDINGS_DIR / filename
+    if not file_path.exists():
+        abort(404)
+    return send_file(file_path, mimetype="audio/wav")
+
+
+@app.route("/api/spectrogram/<path:filename>")
+def spectrogram(filename: str):
+    """Generate and return a PNG spectrogram for ``filename``."""
+
+    file_path = RECORDINGS_DIR / filename
+    if not file_path.exists():
+        abort(404)
+
+    y, sr = librosa.load(file_path, sr=None)
+    spec = librosa.stft(y)
+    spec_db = librosa.amplitude_to_db(np.abs(spec), ref=np.max)
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    librosa.display.specshow(spec_db, sr=sr, x_axis="time", y_axis="hz", ax=ax)
+    ax.set(title="Spectrogram")
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format="png", bbox_inches="tight")
+    plt.close(fig)
+    buf.seek(0)
+
+    return send_file(buf, mimetype="image/png")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5010, debug=True)
+


### PR DESCRIPTION
## Summary
- add Flask-based server to serve modern dashboard, audio, and spectrogram endpoints
- implement Bootstrap dashboard showing latest recording, spectrogram, and player
- document new UI and install Flask/matplotlib dependencies

## Testing
- `pip install Flask==2.3.2 matplotlib`
- `pip install apprise==1.2.1`
- `pip install pytest-mock==3.7.0`
- `pytest -q` *(fails: assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_688d7bfd976c8328bb9c0f92dd646d62